### PR TITLE
[WIP] UI Specifiable Sketches

### DIFF
--- a/sketch/src/doop.rs
+++ b/sketch/src/doop.rs
@@ -1,0 +1,97 @@
+use super::*;
+use std::f64::consts::{E, PI, TAU};
+
+/// A series of lightly complex sine modulated rings around the center of the
+/// page with optional text cutout.
+#[sketch]
+pub struct Doop {
+    /// The number of rings to draw
+    #[param(default = 35, range=2..=60)]
+    plevels: u64,
+
+    /// The number of steps to sample the sine wave(s) at during a circular
+    /// sweep of a ring
+    #[param(default = 33, range=2..=50)]
+    rotational_steps: u64,
+
+    /// When set, the resulting bloom will be one single path, rotated LEVELS
+    /// amount of times, instead of distrete closed paths per LEVEL
+    spiral: bool,
+
+    /// Display overlaid text
+    display_text: bool,
+}
+
+fn exp_dec(lambda: f64, t: f64) -> f64 {
+    E.powf(-lambda * t)
+}
+fn sin_component(amplitude: f64, freq: f64, t: f64, phase: f64) -> f64 {
+    amplitude * (TAU * freq * t + phase).sin()
+}
+
+impl Sketch for Doop {
+    fn exec(&self) -> SketchResult<Canvas> {
+        const WIDTH: f64 = 11. * INCH;
+        const HEIGHT: f64 = 17. * INCH;
+        let mut canvas = Canvas::new(point(0, 0), Size::new(11. * INCH, 17. * INCH));
+
+        let center = point(WIDTH / 2., HEIGHT / 2.);
+
+        let text = TextBuilder::new()
+            .size(300.)
+            .origin(point(1. * INCH, 3. * INCH))
+            .line_padding(-10.)
+            .text_line("a desire")
+            .text_line("by")
+            .text_line("another")
+            .text_line("paralysis")
+            .build()
+            .unwrap();
+
+        let steps = self.rotational_steps;
+        let plevels = self.plevels;
+        let th_delta = TAU / steps as f64;
+        let mut points = vec![];
+        for level in 0..plevels {
+            if !self.spiral {
+                points.clear()
+            };
+            let level_prog = level as f64 / plevels as f64;
+            for step in 0..steps {
+                let th = step as f64 * th_delta;
+                let step_prog = step as f64 / steps as f64;
+                let base_dist = 4.25 * INCH - 2.5 * level_prog * INCH;
+                let sin_mod = sin_component(0.75 * INCH, 5., step_prog, 0. * PI)
+                    * exp_dec(4., level_prog)
+                    + sin_component(0.25 * INCH, 15., step_prog, PI / 2.) * exp_dec(5., level_prog);
+                //+ sin_component(1. * INCH, 2., step_prog, 1.5*PI) * exp_dec(5., level_prog);
+                let dist = (base_dist + sin_mod) * Vec2::from_angle(th);
+                points.push(center + dist);
+            }
+            if !self.spiral {
+                let poly = Poly::new_smooth(&points);
+                if self.display_text {
+                    let diff = poly.difference(&text);
+                    canvas.add(diff);
+                } else {
+                    canvas.add(poly);
+                }
+            }
+        }
+        if self.spiral {
+            let path = Path::from_points_smooth(&points);
+            if self.display_text {
+                let diff = path.difference(&text);
+                canvas.add(diff);
+            } else {
+                canvas.add(path);
+            }
+        }
+
+        if self.display_text {
+            canvas.add(text);
+        }
+
+        Ok(canvas)
+    }
+}

--- a/sketch_derive/src/codegen.rs
+++ b/sketch_derive/src/codegen.rs
@@ -3,6 +3,55 @@ use quote::quote;
 use std::str::FromStr;
 use syn::Type;
 
+pub fn consts_sketch_meta_tokens(sketch: &SketchStruct) -> proc_macro2::TokenStream {
+    let attrs = &sketch.sketch_attrs;
+    let name = if let Some(n) = &attrs.name {
+        quote!( pub const NAME: &'static str = #n; )
+    } else {
+        // TODO: use `heck` crate to beautify name
+        let n = sketch.name.to_string();
+        quote!( pub const NAME: &'static str = #n; )
+    };
+    let desc = if let Some(d) = &attrs.desc {
+        quote!( pub const DESC: &'static str = #d; )
+    } else {
+        quote!(
+            pub const DESC: &'static str = "";
+        )
+    };
+
+    quote!(
+        #name
+        #desc
+    )
+}
+
+pub fn impl_sketchmetadata_tokens(sketch: &SketchStruct) -> proc_macro2::TokenStream {
+    let ident = &sketch.name;
+    let attrs = &sketch.sketch_attrs;
+    let name = if let Some(n) = &attrs.name {
+        quote!( const NAME: &'static str = #n; )
+    } else {
+        // TODO: use `heck` crate to beautify name
+        let n = sketch.name.to_string();
+        quote!( const NAME: &'static str = #n; )
+    };
+    let desc = if let Some(d) = &attrs.desc {
+        quote!( const DESC: &'static str = #d; )
+    } else {
+        quote!(
+            const DESC: &'static str = "";
+        )
+    };
+
+    quote!(
+        impl SketchMetadata for #ident {
+            #name
+            #desc
+        }
+    )
+}
+
 pub fn impl_default_tokens(name: &syn::Ident, params: &[SketchParam]) -> proc_macro2::TokenStream {
     let param_def_tokens: Vec<proc_macro2::TokenStream> = params
         .iter()

--- a/sketch_derive/src/lib.rs
+++ b/sketch_derive/src/lib.rs
@@ -16,13 +16,70 @@ pub fn sketch(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let params = &sketch_struct.params;
 
     let struct_tokens = quote!( #sketch_struct  );
+    //let impl_sketchmetadata = impl_sketchmetadata_tokens(&sketch_struct);
+    let consts_sketch_meta = consts_sketch_meta_tokens(&sketch_struct);
     let impl_sketchaccess = impl_sketchaccess_tokens(name, params);
     let impl_default = impl_default_tokens(name, params);
 
     quote! (
+        #consts_sketch_meta
         #struct_tokens
         #impl_default
         #impl_sketchaccess
     )
     .into()
+}
+
+#[derive(Debug)]
+struct SketchListSubMod {
+    use_item: syn::ItemUse,
+    //mod_path: syn::Ident,
+    //sketch_struct: syn::Ident,
+}
+
+#[derive(Debug)]
+struct SketchListMod {
+    sketches: Vec<SketchListSubMod>,
+}
+
+impl syn::parse::Parse for SketchListMod {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // Parsing
+        let vis: syn::Visibility = input.parse()?;
+        let mod_token: syn::Token![mod] = input.parse()?;
+        let name: syn::Ident = input.parse()?;
+        let braced_content;
+        syn::braced!(braced_content in input);
+        let sketches_raw: syn::punctuated::Punctuated<SketchListSubMod, syn::Token![;]> =
+            braced_content.parse_terminated(SketchListSubMod::parse)?;
+        let sketches = sketches_raw.into_pairs().map(|p| p.into_value()).collect();
+
+        Ok(Self { sketches })
+    }
+}
+
+impl syn::parse::Parse for SketchListSubMod {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        println!("in SketchListSubMod");
+        let use_item: syn::ItemUse = input.parse()?;
+
+        //let full_path = use_stmt.tree.
+        //let mod_path = full_path.segments.
+
+        println!("sketch item: {:?}", use_item);
+        Ok(Self {
+            use_item,
+            //mod_path,
+            //sketch_struct,
+        })
+    }
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn sketchlist(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let mod_item: SketchListMod = syn::parse(input).unwrap();
+    println!("\nmod_item: {:?}\n", mod_item);
+
+    quote!().into()
 }

--- a/ui/src/app/mod.rs
+++ b/ui/src/app/mod.rs
@@ -4,7 +4,7 @@ use eframe::{
     epi,
 };
 use nightgraphics::render::EguiRenderer;
-use nightsketch::{ParamKind, ParamMetadata, ParamRange, SketchList};
+use nightsketch::{ParamKind, ParamMetadata, ParamRange, Sketch, Sketches};
 
 mod drawing;
 use drawing::Drawing;
@@ -17,9 +17,13 @@ pub struct NightgraphApp {
     #[serde(skip)]
     drawing: Drawing,
 
-    sketch: SketchList,
+    #[serde(skip)]
+    sketch: Box<dyn Sketch>,
 
     ui_scale: Option<f32>,
+
+    #[serde(skip)]
+    sketches: Sketches,
 
     // TODO: previous sessions mode using persistence.
     // saves the sketch struct values, but not the rendered shapes
@@ -29,9 +33,11 @@ pub struct NightgraphApp {
 
 impl Default for NightgraphApp {
     fn default() -> Self {
-        let sketch = SketchList::default();
+        let sketches = Sketches::default();
+        let sketch = sketches.sketch();
         let params = sketch.param_metadata();
         Self {
+            sketches,
             sketch,
             drawing: Drawing::default(),
             params,
@@ -220,6 +226,14 @@ impl epi::App for NightgraphApp {
                 ui.collapsing("View Settings", |ui| {
                     self.view_settings_grid(ui);
                 });
+
+                let current_sketch = self.sketches;
+                ui.radio_value(&mut self.sketches, Sketches::Blossom, "Blossom");
+                ui.radio_value(&mut self.sketches, Sketches::Doop, "Doop");
+                if current_sketch != self.sketches {
+                    self.sketch = self.sketches.sketch();
+                    self.params = self.sketch.param_metadata();
+                }
                 self.param_grid(ui);
             });
 


### PR DESCRIPTION
## Status
![Screenshot of nightgraph-ui with specifiable sketches](https://user-images.githubusercontent.com/5200550/138808461-5c2e3c03-2098-48a2-b503-2f054276a051.png)
right now, this PR is just a rough hard-coding of the type of code that a macro like `#[sketchlist]` would generate.

Aesthetically (in both the UI and the macros) there is a bit to figure out still, but the foundation seems solid enough.

## Todo
- [ ] Add `sketchlist` macro.  The scratch commit in this PR has it as an attribute macro, but that might be kind of clunky since it needs to apply to an item. In this case, a module is the only semi-appropriate item, and even that feels clunky since its contents are not really going to be passed through to the resulting code.  A better choice might be a proc macro [function-like macro](https://doc.rust-lang.org/book/ch19-06-macros.html#function-like-macros).
- [ ] Prettier sketch selection in UI.  Right now it is hard-coded radio buttons as a proof of concept. `egui` selectable labels might be more visually appealing, but a drop down might make the most sense.
- [ ] Adding a sketch to the sketch list (in whatever form it takes) should be a one line operation (regardless of egui or clap).