### PR TITLE
Restructure UI crate

### DIFF
--- a/ui/src/app/drawing.rs
+++ b/ui/src/app/drawing.rs
@@ -137,4 +137,26 @@ impl Drawing {
 
         painter.extend(self.translate_scale(to_screen));
     }
+
+    pub fn settings_grid(&mut self, ui: &mut egui::Ui) {
+        egui::Grid::new("view_settings_grid")
+            .num_columns(2)
+            .striped(false)
+            .show(ui, |ui| {
+                ui.label("Draw debug geometry");
+                ui.checkbox(&mut self.draw_debug_geom, "");
+                ui.end_row();
+                ui.label("Draw page outline");
+                ui.checkbox(&mut self.draw_page_outline, "");
+                ui.end_row();
+
+                ui.label("Page color");
+                egui::color_picker::color_edit_button_srgba(
+                    ui,
+                    &mut self.bg_color,
+                    egui::color_picker::Alpha::OnlyBlend,
+                );
+                ui.end_row();
+            });
+    }
 }

--- a/ui/src/app/mod.rs
+++ b/ui/src/app/mod.rs
@@ -12,6 +12,7 @@ use sketch_control::*;
 
 #[cfg_attr(feature = "persistence", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "persistence", serde(default))]
+#[derive(Default)]
 pub struct NightgraphApp {
     // Temporarily opt out of state persistence on drawing until the sketch
     // and associated info is actually stored in the app state
@@ -22,16 +23,6 @@ pub struct NightgraphApp {
     sketch_control: SketchControl,
 
     ui_scale: Option<f32>,
-}
-
-impl Default for NightgraphApp {
-    fn default() -> Self {
-        Self {
-            sketch_control: SketchControl::default(),
-            drawing: Drawing::default(),
-            ui_scale: Default::default(),
-        }
-    }
 }
 
 impl NightgraphApp {

--- a/ui/src/app/mod.rs
+++ b/ui/src/app/mod.rs
@@ -3,8 +3,6 @@ use eframe::{
     egui::{FontDefinitions, FontFamily, Style},
     epi,
 };
-use nightgraphics::render::EguiRenderer;
-use nightsketch::{ParamKind, ParamMetadata, ParamRange, SketchList};
 
 mod drawing;
 use drawing::Drawing;
@@ -37,46 +35,7 @@ impl Default for NightgraphApp {
 }
 
 impl NightgraphApp {
-
-    fn view_settings_grid(&mut self, ui: &mut egui::Ui) {
-        egui::Grid::new("view_settings_grid")
-            .num_columns(2)
-            .striped(false)
-            .show(ui, |ui| {
-                ui.label("Draw debug geometry");
-                ui.checkbox(&mut self.drawing.draw_debug_geom, "");
-                ui.end_row();
-                ui.label("Draw page outline");
-                ui.checkbox(&mut self.drawing.draw_page_outline, "");
-                ui.end_row();
-
-                ui.label("Page color");
-                egui::color_picker::color_edit_button_srgba(
-                    ui,
-                    &mut self.drawing.bg_color,
-                    egui::color_picker::Alpha::OnlyBlend,
-                );
-                ui.end_row();
-            });
-    }
-}
-
-impl epi::App for NightgraphApp {
-    fn name(&self) -> &str {
-        "nightgraph ui"
-    }
-
-    fn setup(
-        &mut self,
-        ctx: &egui::CtxRef,
-        _frame: &mut epi::Frame<'_>,
-        _storage: Option<&dyn epi::Storage>,
-    ) {
-        #[cfg(feature = "persistence")]
-        if let Some(storage) = _storage {
-            *self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default()
-        }
-
+    fn setup_fonts(&mut self, ctx: &egui::CtxRef) {
         let mut fonts = FontDefinitions::default();
         fonts.font_data.insert(
             "Jost*".to_owned(),
@@ -116,6 +75,26 @@ impl epi::App for NightgraphApp {
             .insert(0, "Monofur".to_owned());
 
         ctx.set_fonts(fonts);
+    }
+}
+
+impl epi::App for NightgraphApp {
+    fn name(&self) -> &str {
+        "nightgraph ui"
+    }
+
+    fn setup(
+        &mut self,
+        ctx: &egui::CtxRef,
+        _frame: &mut epi::Frame<'_>,
+        _storage: Option<&dyn epi::Storage>,
+    ) {
+        #[cfg(feature = "persistence")]
+        if let Some(storage) = _storage {
+            *self = epi::get_value(storage, epi::APP_KEY).unwrap_or_default()
+        }
+
+        self.setup_fonts(ctx);
 
         let style = Style {
             visuals: egui::Visuals::light(),
@@ -142,7 +121,7 @@ impl epi::App for NightgraphApp {
                 ui.add(egui::Separator::default().spacing(15.));
 
                 ui.collapsing("View Settings", |ui| {
-                    self.view_settings_grid(ui);
+                    self.drawing.settings_grid(ui);
                 });
                 ui.collapsing("Sketch Settings", |ui| {
                     self.sketch_control.param_grid(ui);

--- a/ui/src/app/sketch_control.rs
+++ b/ui/src/app/sketch_control.rs
@@ -1,0 +1,102 @@
+use eframe::egui;
+use nightgraphics::render::EguiRenderer;
+use nightsketch::*;
+
+pub struct SketchControl {
+    sketch: SketchList,
+    params: Vec<ParamMetadata>,
+    pub needs_render: bool,
+}
+
+impl Default for SketchControl {
+    fn default() -> Self {
+        let sketch = SketchList::default();
+        SketchControl {
+            sketch: SketchList::default(),
+            params: sketch.param_metadata(),
+            needs_render: true,
+        }
+    }
+}
+
+impl SketchControl {
+    fn param_grid_contents(&mut self, ui: &mut egui::Ui) {
+        for param in &self.params {
+            let sketch = &mut self.sketch;
+            let id = param.id;
+            match param.kind {
+                ParamKind::Int => {
+                    ui.label(param.name);
+                    let val = sketch.mut_int_by_id(id).unwrap();
+                    let init = *val;
+                    let dragval = if let Some(ParamRange::Int(range)) = &param.range {
+                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                    } else {
+                        egui::widgets::DragValue::new(val)
+                    };
+                    ui.add(dragval);
+                    if *val != init {
+                        self.needs_render = true;
+                        //drawing.rerender(sketch.exec().unwrap().render_egui());
+                    }
+                }
+                ParamKind::Float => {
+                    ui.label(param.name);
+                    let val = sketch.mut_float_by_id(id).unwrap();
+                    let init = *val;
+                    let dragval = if let Some(ParamRange::Float(range)) = &param.range {
+                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                    } else {
+                        egui::widgets::DragValue::new(val)
+                    };
+                    ui.add(dragval);
+                    if (*val - init).abs() > f64::EPSILON {
+                        self.needs_render = true;
+                        //drawing.rerender(sketch.exec().unwrap().render_egui());
+                    }
+                }
+                ParamKind::UInt => {
+                    ui.label(param.name);
+                    let val = sketch.mut_uint_by_id(id).unwrap();
+                    let init = *val;
+                    let dragval = if let Some(ParamRange::Int(range)) = &param.range {
+                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                    } else {
+                        egui::widgets::DragValue::new(val)
+                    };
+                    ui.add(dragval);
+                    if *val != init {
+                        self.needs_render = true;
+                        //drawing.rerender(sketch.exec().unwrap().render_egui());
+                    }
+                }
+                ParamKind::Bool => {
+                    // Checkbox/Label Button box by default
+                    let val = sketch.mut_bool_by_id(id).unwrap();
+                    let init = *val;
+
+                    ui.label(param.name);
+                    ui.add(egui::widgets::Checkbox::new(val, ""));
+                    if *val != init {
+                        self.needs_render = true;
+                        //drawing.rerender(sketch.exec().unwrap().render_egui());
+                    }
+                }
+                // TODO: Showing a label with param name and unsupported would by nice
+                ParamKind::Unsupported => {}
+            }
+            ui.end_row();
+        }
+    }
+    pub fn param_grid(&mut self, ui: &mut egui::Ui) {
+        egui::Grid::new("params_grid")
+            .num_columns(2)
+            .spacing([55.0, 4.0])
+            .striped(false)
+            .show(ui, |ui| self.param_grid_contents(ui));
+    }
+
+    pub fn render(&self) -> SketchResult<(egui::Vec2, Vec<egui::Shape>)> {
+        Ok(self.sketch.exec()?.render_egui())
+    }
+}


### PR DESCRIPTION
Moves sketch related data and associated UI controls to own module (`sketch_control`).

Moves drawing/page controls to `drawing` module.

Moves font setup operations to own function (this pattern should be followed for other setup ops, such as UI scaling, etc.