### PR TITLE
Allow specifying where rendered SVGs are stored

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,10 @@ use serde::{Deserialize, Serialize};
 struct Opts {
     #[clap(subcommand)]
     sketch: SketchSubcommand,
+
+    /// Path where the resulting SVG file is stored
+    #[clap(long, default_value = "drawing.svg")]
+    output: String,
 }
 
 fn main() {
@@ -16,6 +20,9 @@ fn main() {
     // JSON serialization will eventually be used for config file
     // saving and loading
     println!("{}", opts_json);
-    let canvas = opts.sketch.exec().unwrap();
-    canvas.render_svg();
+    let canvas = opts.sketch.exec();
+    match canvas {
+        Ok(c) => c.render_svg(&opts.output),
+        Err(e) => println!("Error rendering sketch: {:?}", e),
+    }
 }

--- a/graphics/examples/basic.rs
+++ b/graphics/examples/basic.rs
@@ -35,5 +35,5 @@ fn main() {
         .unwrap();
     canvas.add(text);
 
-    canvas.render_svg();
+    canvas.render_svg("test_drawing.svg");
 }

--- a/graphics/src/render/svg.rs
+++ b/graphics/src/render/svg.rs
@@ -4,16 +4,16 @@ use svg::node::element::{path::Data, Circle as SvgCircle, Path as SvgPath};
 use svg::Document;
 
 pub trait SvgRenderer {
-    fn render_svg(&self) {}
+    fn render_svg(&self, path: &str);
 }
 
 impl SvgRenderer for Canvas {
-    fn render_svg(&self) {
+    fn render_svg(&self, path: &str) {
         let doc = Document::new()
             .set("width", self.width())
             .set("height", self.height());
         let rendered_doc = self.render(doc);
-        svg::save("image.svg".to_string(), &rendered_doc).expect("Unable to save SVG");
+        svg::save(path.to_string(), &rendered_doc).expect("Unable to save SVG");
     }
 }
 
@@ -51,25 +51,6 @@ impl SvgRenderable for Circle {
     }
 }
 
-/*
-impl SvgRenderable<SvgLine> for geometry::Line {
-    fn to_svg(&self) -> RenderResult<SvgLine> {
-        let p1 = self.inner().p0;
-        let p2 = self.inner().p1;
-        Ok(SvgLine::new()
-            .set("fill", "none")
-            // TODO: allow stroke to be set at or before render time
-            .set("stroke", "black")
-            .set("stroke-width", "0.5mm")
-            .set("x1", p1.x)
-            .set("y1", p1.y)
-            .set("x2", p2.x)
-            .set("y2", p2.y))
-    }
-}
-*/
-
-//impl<T: geometry::WrapsShape<Inner = kurbo::BezPath>> SvgRenderable<SvgPath> for T
 impl SvgRenderable for Shape {
     fn render(&self, doc: Document) -> Document {
         match self {


### PR DESCRIPTION
Adds a `path` argument to `nightgraphics::render::svg::SvgRenderer` and an `--output` arg to `nightgraph-cli`

### `nightgraph-cli`
```
nightgraph-cli 0.1.0

Kyle Kneitinger <kyle@kneit.in>

A runner for nightgraph sketches

USAGE:
    nightgraph-cli [OPTIONS] <SUBCOMMAND>

OPTIONS:
    -h, --help               Print help information
        --output <OUTPUT>    Path where the resulting SVG file is stored [default: drawing.svg]
    -V, --version            Print version information

SUBCOMMANDS:
    blossom    A series of lightly complex sine modulated rings around the center of the page
               with optional text cutout
    help       Print this message or the help of the given subcommand(s)
```
Fixes #12 