### PR TITLE
Allow specification of stroke widths

### DIFF
--- a/graphics/src/geometry/circle.rs
+++ b/graphics/src/geometry/circle.rs
@@ -1,6 +1,6 @@
 use super::Vec2;
-use super::DEFAULT_ACCURACY;
 use super::{Path, Point, Shape, Shaped, DEFAULT_TOLERANCE};
+use super::{DEFAULT_ACCURACY, DEFAULT_STROKE_WIDTH};
 use kurbo::BezPath;
 use kurbo::Circle as KurboCircle;
 use kurbo::Shape as KurboShape;
@@ -8,12 +8,14 @@ use kurbo::Shape as KurboShape;
 #[derive(Debug, Clone, Copy)]
 pub struct Circle {
     inner: KurboCircle,
+    stroke_width: f64,
 }
 
 impl Circle {
     pub fn new(center: impl Into<Point>, radius: f64) -> Circle {
         Self {
             inner: KurboCircle::new(center, radius),
+            stroke_width: DEFAULT_STROKE_WIDTH,
         }
     }
 
@@ -31,6 +33,7 @@ impl Circle {
         let ts = kurbo::TranslateScale::new(translation, 1.0);
         Self {
             inner: ts * self.inner,
+            stroke_width: self.stroke_width,
         }
     }
 }
@@ -56,6 +59,9 @@ impl Shaped for Circle {
     }
     fn area(&self) -> f64 {
         self.inner.area()
+    }
+    fn stroke(&self) -> f64 {
+        self.stroke_width
     }
 }
 

--- a/graphics/src/geometry/line.rs
+++ b/graphics/src/geometry/line.rs
@@ -1,15 +1,20 @@
-use super::{GeomResult, Path, Point, Shape, Shaped, Vec2, DEFAULT_ACCURACY, DEFAULT_TOLERANCE};
+use super::{
+    GeomResult, Path, Point, Shape, Shaped, Vec2, DEFAULT_ACCURACY, DEFAULT_STROKE_WIDTH,
+    DEFAULT_TOLERANCE,
+};
 use kurbo::{BezPath, Line as KurboLine, ParamCurve, Shape as KurboShape};
 
 #[derive(Copy, Clone, Debug)]
 pub struct Line {
     inner: KurboLine,
+    stroke_width: f64,
 }
 
 impl Line {
     pub fn new(a: Point, b: Point) -> GeomResult<Line> {
         Ok(Self {
             inner: KurboLine::new(a, b),
+            stroke_width: DEFAULT_STROKE_WIDTH,
         })
     }
 
@@ -31,6 +36,7 @@ impl Line {
         let ts = kurbo::TranslateScale::new(translation, 1.0);
         Self {
             inner: ts * self.inner,
+            stroke_width: self.stroke_width,
         }
     }
 }
@@ -41,6 +47,9 @@ impl Shaped for Line {
     }
     fn to_path(&self) -> Path {
         Path::from(self.inner.into_path(DEFAULT_TOLERANCE))
+    }
+    fn stroke(&self) -> f64 {
+        self.stroke_width
     }
     fn as_bezpath(&self) -> BezPath {
         self.inner.into_path(DEFAULT_TOLERANCE)

--- a/graphics/src/geometry/mod.rs
+++ b/graphics/src/geometry/mod.rs
@@ -30,6 +30,7 @@ pub fn avg_point(p1: Point, p2: Point) -> Point {
 }
 
 pub const DEFAULT_TOLERANCE: f64 = 1e-1;
+pub const DEFAULT_STROKE_WIDTH: f64 = 0.45 * crate::units::MM;
 
 pub enum Shape {
     Path(Path),
@@ -84,6 +85,7 @@ pub trait Shaped {
     fn to_path(&self) -> Path;
     fn as_bezpath(&self) -> BezPath;
     fn perimeter(&self) -> f64;
+    fn stroke(&self) -> f64;
     fn difference(&self, other: &dyn Shaped) -> Path {
         if self
             .bounding_box()

--- a/graphics/src/geometry/mod.rs
+++ b/graphics/src/geometry/mod.rs
@@ -65,6 +65,10 @@ impl Shape {
         self.inner().to_path()
     }
 
+    pub fn stroke(&self) -> f64 {
+        self.inner().stroke()
+    }
+
     pub fn to_lines(&self) -> Vec<Line> {
         self.inner().to_lines()
     }

--- a/graphics/src/geometry/path.rs
+++ b/graphics/src/geometry/path.rs
@@ -13,6 +13,7 @@ pub struct PathBuilder {
     points: Vec<Point>,
     closed: bool,
     cmds: Vec<PathEl>,
+    stroke_width: f64,
     precompute: bool,
     mode: PathBuildMode,
 }
@@ -24,12 +25,18 @@ impl PathBuilder {
             closed: false,
             cmds: vec![],
             precompute: false,
+            stroke_width: DEFAULT_STROKE_WIDTH,
             mode: PathBuildMode::Unknown,
         }
     }
 
     pub fn closed(&mut self) -> &mut Self {
         self.closed = true;
+        self
+    }
+
+    pub fn stroke_width(&mut self, stroke_width: f64) -> &mut Self {
+        self.stroke_width = stroke_width;
         self
     }
 
@@ -122,8 +129,7 @@ impl PathBuilder {
             None
         };
 
-        // TODO: Add method
-        let stroke_width = DEFAULT_STROKE_WIDTH;
+        let stroke_width = self.stroke_width;
 
         Ok(Path {
             inner,

--- a/graphics/src/geometry/path.rs
+++ b/graphics/src/geometry/path.rs
@@ -122,9 +122,13 @@ impl PathBuilder {
             None
         };
 
+        // TODO: Add method
+        let stroke_width = DEFAULT_STROKE_WIDTH;
+
         Ok(Path {
             inner,
             bounding_box,
+            stroke_width,
         })
     }
 }
@@ -139,6 +143,7 @@ impl Default for PathBuilder {
 pub struct Path {
     inner: BezPath,
     bounding_box: Option<kurbo::Rect>,
+    stroke_width: f64,
 }
 
 impl From<BezPath> for Path {
@@ -146,6 +151,7 @@ impl From<BezPath> for Path {
         Self {
             inner: bez_path,
             bounding_box: None,
+            stroke_width: DEFAULT_STROKE_WIDTH,
         }
     }
 }
@@ -158,6 +164,7 @@ impl Path {
         Self {
             inner,
             bounding_box: None,
+            stroke_width: DEFAULT_STROKE_WIDTH,
         }
     }
 
@@ -175,6 +182,7 @@ impl Path {
             [PathEl::MoveTo(_), _, ..] => Ok(Self {
                 inner: BezPath::from_vec(Vec::from(commands)),
                 bounding_box: None,
+                stroke_width: DEFAULT_STROKE_WIDTH,
             }),
             [_, ..] => Err(GeomError::path_error(
                 "paths must start with a MoveTo command",
@@ -299,6 +307,7 @@ impl Path {
         Self {
             inner: ts * self.inner.clone(),
             bounding_box: self.bounding_box,
+            stroke_width: self.stroke_width,
         }
     }
 }
@@ -309,6 +318,9 @@ impl Shaped for Path {
     }
     fn as_bezpath(&self) -> BezPath {
         self.inner.clone()
+    }
+    fn stroke(&self) -> f64 {
+        self.stroke_width
     }
     fn as_shape(&self) -> Shape {
         Shape::Path(self.clone())

--- a/graphics/src/geometry/poly.rs
+++ b/graphics/src/geometry/poly.rs
@@ -5,6 +5,7 @@ use kurbo::Shape as KurboShape;
 #[derive(Clone, Debug)]
 pub struct Poly {
     inner: BezPath,
+    stroke_width: f64,
 }
 
 impl Poly {
@@ -22,7 +23,10 @@ impl Poly {
             }
             _ => return Err(GeomError::malformed_path("Poly has less than three points")),
         }
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            stroke_width: DEFAULT_STROKE_WIDTH,
+        })
     }
     fn inner(&self) -> BezPath {
         self.inner.clone()
@@ -31,6 +35,7 @@ impl Poly {
     pub fn new_smooth(points: &[Point]) -> Self {
         Poly {
             inner: Path::from_points_smooth_closed(points).as_bezpath(),
+            stroke_width: DEFAULT_STROKE_WIDTH,
         }
     }
 
@@ -38,6 +43,7 @@ impl Poly {
         let ts = kurbo::TranslateScale::new(translation, 1.0);
         Self {
             inner: ts * self.inner.clone(),
+            stroke_width: self.stroke_width,
         }
     }
 }
@@ -45,6 +51,9 @@ impl Poly {
 impl Shaped for Poly {
     fn as_shape(&self) -> Shape {
         Shape::Poly(self.clone())
+    }
+    fn stroke(&self) -> f64 {
+        self.stroke_width
     }
     fn to_path(&self) -> Path {
         Path::from(self.inner())

--- a/graphics/src/geometry/text.rs
+++ b/graphics/src/geometry/text.rs
@@ -1,4 +1,4 @@
-use super::{point, GeomError, GeomResult, Path, PathEl, Point};
+use super::{point, GeomError, GeomResult, Path, PathBuilder, PathEl, Point, DEFAULT_STROKE_WIDTH};
 use rusttype::{Font, OutlineBuilder, Scale, Vector};
 use std::fs::File;
 use std::io::BufReader;
@@ -10,6 +10,7 @@ pub struct TextBuilder<'a> {
     text_lines: Vec<&'a str>,
     line_padding: Option<f64>,
     origin: Option<Point>,
+    stroke_width: Option<f64>,
 }
 
 #[allow(clippy::new_without_default)]
@@ -21,6 +22,7 @@ impl<'a> TextBuilder<'a> {
             text_lines: vec![],
             line_padding: None,
             origin: None,
+            stroke_width: None,
         }
     }
 
@@ -36,6 +38,11 @@ impl<'a> TextBuilder<'a> {
 
     pub fn text_line(mut self, text: &'a str) -> Self {
         self.text_lines.push(text);
+        self
+    }
+
+    pub fn stroke_width(mut self, width: f64) -> Self {
+        self.stroke_width = Some(width);
         self
     }
 
@@ -119,8 +126,17 @@ impl<'a> TextBuilder<'a> {
                     y: (v_metrics.ascent + line_padding as f32),
                 };
         }
-        //Ok(paths)
-        Path::from_commands(&combined_cmds)
+
+        let stroke_width = match self.stroke_width {
+            Some(w) => w,
+            None => DEFAULT_STROKE_WIDTH,
+        };
+
+        PathBuilder::new()
+            .commands(&combined_cmds)
+            .precompute()
+            .stroke_width(stroke_width)
+            .build()
     }
 }
 

--- a/graphics/src/render/egui.rs
+++ b/graphics/src/render/egui.rs
@@ -1,5 +1,5 @@
 use crate::canvas::*;
-use crate::geometry::{Circle, Point, Shape};
+use crate::geometry::{Circle, Point, Shape, Shaped};
 use egui::{Color32, Pos2, Shape as EguiShape, Stroke};
 
 const WHITE: Color32 = Color32::from_rgb(255, 255, 255);
@@ -47,7 +47,7 @@ impl EguiRenderable for Circle {
             Pos2::new(c.x as f32, c.y as f32),
             self.inner().radius as f32,
             // TODO: allow stroke to be set at or before render time
-            Stroke::new(2., WHITE),
+            Stroke::new(self.stroke() as f32, WHITE),
         )]
     }
 }
@@ -66,7 +66,7 @@ impl EguiRenderable for Shape {
                     .iter()
                     .map(|line| EguiShape::LineSegment {
                         points: [p(&line.p0()), p(&line.p1())],
-                        stroke: Stroke::new(2., WHITE),
+                        stroke: Stroke::new(self.stroke() as f32, WHITE),
                     })
                     .collect()
             }

--- a/graphics/src/render/svg.rs
+++ b/graphics/src/render/svg.rs
@@ -1,5 +1,5 @@
 use crate::canvas::*;
-use crate::geometry::{Circle, PathEl, Point, Shape};
+use crate::geometry::{Circle, PathEl, Point, Shape, Shaped};
 use svg::node::element::{path::Data, Circle as SvgCircle, Path as SvgPath};
 use svg::Document;
 
@@ -41,9 +41,8 @@ impl SvgRenderable for Circle {
     fn render(&self, doc: Document) -> Document {
         let c = SvgCircle::new()
             .set("fill", "none")
-            // TODO: allow stroke to be set at or before render time
             .set("stroke", "black")
-            .set("stroke-width", "0.5mm")
+            .set("stroke-width", self.stroke())
             .set("cx", self.center().x)
             .set("cy", self.center().y)
             .set("r", self.radius());
@@ -75,9 +74,8 @@ impl SvgRenderable for Shape {
                 doc.add(
                     SvgPath::new()
                         .set("fill", "none")
-                        // TODO: allow stroke to be set at or before render time
                         .set("stroke", "black")
-                        .set("stroke-width", "0.5mm")
+                        .set("stroke-width", self.stroke())
                         .set("fill-rule", "evenodd")
                         .set("d", d),
                 )

--- a/ui/src/app/drawing.rs
+++ b/ui/src/app/drawing.rs
@@ -58,16 +58,25 @@ impl Drawing {
                 EguiShape::Circle(circ) => EguiShape::circle_stroke(
                     transformation * circ.center,
                     circ.radius * transformation.scale().x,
-                    circ.stroke,
+                    egui::Stroke {
+                        color: circ.stroke.color,
+                        width: transformation.scale().x * circ.stroke.width,
+                    },
                 ),
                 EguiShape::LineSegment { points, stroke } => EguiShape::line_segment(
                     [transformation * points[0], transformation * points[1]],
-                    *stroke,
+                    egui::Stroke {
+                        color: stroke.color,
+                        width: transformation.scale().x * stroke.width,
+                    },
                 ),
                 EguiShape::Rect(rect) => EguiShape::rect_stroke(
                     transformation.transform_rect(rect.rect),
                     rect.corner_radius,
-                    rect.stroke,
+                    egui::Stroke {
+                        color: rect.stroke.color,
+                        width: transformation.scale().x * rect.stroke.width,
+                    },
                 ),
                 _ => EguiShape::Noop,
             })


### PR DESCRIPTION
Previously, stroke widths were all set to a hard coded value (0.5mm for SVG, 2px for `egui`), and there was no way for individual shapes to have different stroke widths.

Now, a `stroke_width` field is present on all shapes, and an option exists for setting them in `TextBuilder` and `PathBuilder`.

Additionally, paths drawn in `nightgraph-ui` were a fixed size regardless of zoom level.  Now they scale accordingly.