### PR TITLE
Minor fix collection

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 [dependencies]
 nightgraphics = { path = "../graphics" }
 nightsketch = { path = "../sketch", features = ["cli"] }
-clap = "3.0.0-beta.5"
+clap = {version = "3.0.0-rc.0", features = ["derive", "cargo"] }
 serde = {version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0"}

--- a/graphics/src/geometry/poly.rs
+++ b/graphics/src/geometry/poly.rs
@@ -9,6 +9,12 @@ pub struct PolyBuilder {
     precompute: bool,
 }
 
+impl Default for PolyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PolyBuilder {
     pub fn new() -> Self {
         Self {

--- a/sketch/Cargo.toml
+++ b/sketch/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 [dependencies]
 nightgraphics = { path = "../graphics" }
 nightsketch_derive = { path = "../sketch_derive" }
-clap = { version = "3.0.0-beta.5", optional = true }
+clap = { version = "3.0.0-rc.0", optional = true }
 serde = {version = "1.0", features = ["derive"], optional = true }
 rand = "0.8"
 rand_pcg = "0.3"
@@ -18,5 +18,5 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = []
-cli = ["clap", "nightsketch_derive/cli"]
+cli = ["serde_support", "clap", "clap/derive", "nightsketch_derive/cli"]
 serde_support = ["serde", "nightsketch_derive/serde_support"]

--- a/sketch/Cargo.toml
+++ b/sketch/Cargo.toml
@@ -13,6 +13,8 @@ clap = { version = "3.0.0-beta.5", optional = true }
 serde = {version = "1.0", features = ["derive"], optional = true }
 rand = "0.8"
 rand_pcg = "0.3"
+# Required for rand to work on wasm
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = []

--- a/sketch/src/sketches/weather.rs
+++ b/sketch/src/sketches/weather.rs
@@ -118,8 +118,8 @@ impl Sketch for Weather {
         let ellipse_rings = self.ripple(center, self.freq);
         for e in ellipse_rings {
             let mut p = e.to_path();
-            for n in 0..line_count {
-                p = p.difference(&text_paths[n]);
+            for tp in text_paths.iter() {
+                p = p.difference(tp);
             }
             canvas.add(p);
         }


### PR DESCRIPTION
1. set's the `"js"` function of the `getrandom` crate to enable sketches to use random  values when compiled to wasm.
2. Addresses trivial clippy warnings
3. With the release of the `clap` 3.0.0 release candidates, a `"derive"` feature now needs to be set to use derive macros.