### PR TITLE
Add button to `nightgraph-ui` parameter controls to reset value to default

### DIFF
--- a/sketch/src/metadata.rs
+++ b/sketch/src/metadata.rs
@@ -22,6 +22,9 @@ pub struct ParamMetadata {
     /// The range of appropriate values for this parameter. Only meaningful
     /// for numeric types
     pub range: Option<ParamRange>,
+
+    /// The default value of the parameter
+    pub default: ParamDefault,
 }
 
 /// Describes the type kind of the parameter.
@@ -35,6 +38,19 @@ pub enum ParamKind {
     UInt,
     Bool,
     Unsupported,
+}
+
+/// Describes the default value of the parameter
+///
+/// This is used to allow the parameters' UI controls in `nightgraph-ui` to be
+/// reset to their default values
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ParamDefault {
+    Int(i64),
+    Float(f64),
+    UInt(u64),
+    Bool(bool),
+    None,
 }
 
 /// Describes the range of appropriate values for numeric parameters.

--- a/sketch_derive/src/parse/param.rs
+++ b/sketch_derive/src/parse/param.rs
@@ -61,7 +61,31 @@ impl SketchParam {
             _ => quote!(ParamKind::Unsupported),
         };
 
-        quote!(ParamMetadata { id: #id, name: #name_str, description: #desc, kind: #kind, range: #range})
+        let default_val = match &param_attrs.default {
+            Some(lit) => quote!(#lit),
+            None => quote!(Default::default()),
+        };
+
+        let default = match ty {
+            syn::Type::Path(tp) => match tp.path.segments[0].ident.to_string().as_str() {
+                "isize" | "i128" | "i64" | "i32" | "i16" | "i8" => {
+                    quote!(ParamDefault::Int(#default_val))
+                }
+                "usize" | "u128" | "u64" | "u32" | "u16" | "u8" => {
+                    quote!(ParamDefault::UInt(#default_val))
+                }
+                "f64" | "f32" => {
+                    quote!(ParamDefault::Float(#default_val))
+                }
+                "bool" => {
+                    quote!(ParamDefault::Bool(#default_val))
+                }
+                _ => quote!(ParamDefault::None),
+            },
+            _ => quote!(ParamDefault::None),
+        };
+
+        quote!(ParamMetadata { id: #id, name: #name_str, description: #desc, kind: #kind, range: #range, default: #default})
     }
 
     fn generate_secondary_attrs(&self) -> Option<TokenStream> {

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # eframe's default features includes bundled fonts, which we do not need
-eframe = { version = "0.15", default-features = false, features = ["egui_glium"] }
+eframe = { version = "0.15" }
 nightgraphics = { path = "../graphics" }
 nightsketch = { path = "../sketch" }
 serde = {version = "1.0", features = ["derive"] }

--- a/ui/src/app/sketch_control.rs
+++ b/ui/src/app/sketch_control.rs
@@ -48,52 +48,74 @@ impl SketchControl {
 
         for param in &self.params {
             let sketch = &mut self.sketch;
+            let needs_render = &mut self.needs_render;
             let id = param.id;
             match param.kind {
                 ParamKind::Int => {
                     ui.label(param.name);
-                    let val = sketch.mut_int_by_id(id).unwrap();
-                    let init = *val;
-                    let dragval = if let Some(ParamRange::Int(range)) = &param.range {
-                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
-                    } else {
-                        egui::widgets::DragValue::new(val)
-                    };
-                    ui.add(dragval);
-                    if *val != init {
-                        self.needs_render = true;
-                        //drawing.rerender(sketch.exec().unwrap().render_egui());
-                    }
+                    ui.horizontal(|ui| {
+                        let val = sketch.mut_int_by_id(id).unwrap();
+                        let init = *val;
+                        let dragval = if let Some(ParamRange::Int(range)) = &param.range {
+                            egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                        } else {
+                            egui::widgets::DragValue::new(val)
+                        };
+                        ui.add(dragval);
+                        if ui.button("↺").clicked() {
+                            *val = match param.default {
+                                ParamDefault::Int(i) => i,
+                                _ => Default::default(),
+                            }
+                        }
+                        if *val != init {
+                            *needs_render = true;
+                        }
+                    });
                 }
                 ParamKind::Float => {
                     ui.label(param.name);
-                    let val = sketch.mut_float_by_id(id).unwrap();
-                    let init = *val;
-                    let dragval = if let Some(ParamRange::Float(range)) = &param.range {
-                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
-                    } else {
-                        egui::widgets::DragValue::new(val)
-                    };
-                    ui.add(dragval);
-                    if (*val - init).abs() > f64::EPSILON {
-                        self.needs_render = true;
-                        //drawing.rerender(sketch.exec().unwrap().render_egui());
-                    }
+                    ui.horizontal(|ui| {
+                        let val = sketch.mut_float_by_id(id).unwrap();
+                        let init = *val;
+                        let dragval = if let Some(ParamRange::Float(range)) = &param.range {
+                            egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                        } else {
+                            egui::widgets::DragValue::new(val)
+                        };
+                        ui.add(dragval);
+                        if ui.button("↺").clicked() {
+                            *val = match param.default {
+                                ParamDefault::Float(f) => f,
+                                _ => Default::default(),
+                            }
+                        }
+                        if (*val - init).abs() > f64::EPSILON {
+                            *needs_render = true;
+                        }
+                    });
                 }
                 ParamKind::UInt => {
                     ui.label(param.name);
-                    let val = sketch.mut_uint_by_id(id).unwrap();
-                    let init = *val;
-                    let dragval = if let Some(ParamRange::Int(range)) = &param.range {
-                        egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
-                    } else {
-                        egui::widgets::DragValue::new(val)
-                    };
-                    ui.add(dragval);
-                    if *val != init {
-                        self.needs_render = true;
-                        //drawing.rerender(sketch.exec().unwrap().render_egui());
-                    }
+                    ui.horizontal(|ui| {
+                        let val = sketch.mut_uint_by_id(id).unwrap();
+                        let init = *val;
+                        let dragval = if let Some(ParamRange::Int(range)) = &param.range {
+                            egui::widgets::DragValue::new(val).clamp_range(range.to_owned())
+                        } else {
+                            egui::widgets::DragValue::new(val)
+                        };
+                        ui.add(dragval);
+                        if ui.button("↺").clicked() {
+                            *val = match param.default {
+                                ParamDefault::UInt(i) => i,
+                                _ => Default::default(),
+                            }
+                        }
+                        if *val != init {
+                            *needs_render = true;
+                        }
+                    });
                 }
                 ParamKind::Bool => {
                     // Checkbox/Label Button box by default
@@ -101,11 +123,18 @@ impl SketchControl {
                     let init = *val;
 
                     ui.label(param.name);
-                    ui.add(egui::widgets::Checkbox::new(val, ""));
-                    if *val != init {
-                        self.needs_render = true;
-                        //drawing.rerender(sketch.exec().unwrap().render_egui());
-                    }
+                    ui.horizontal(|ui| {
+                        ui.add(egui::widgets::Checkbox::new(val, ""));
+                        if ui.button("↺").clicked() {
+                            *val = match param.default {
+                                ParamDefault::Bool(b) => b,
+                                _ => Default::default(),
+                            }
+                        }
+                        if *val != init {
+                            *needs_render = true;
+                        }
+                    });
                 }
                 // TODO: Showing a label with param name and unsupported would by nice
                 ParamKind::Unsupported => {}
@@ -116,7 +145,7 @@ impl SketchControl {
     pub fn param_grid(&mut self, ui: &mut egui::Ui) {
         egui::Grid::new("params_grid")
             .num_columns(2)
-            .spacing([55.0, 4.0])
+            .spacing([20.0, 4.0])
             .striped(false)
             .show(ui, |ui| self.param_grid_contents(ui));
     }


### PR DESCRIPTION
Adds a reset button by storing the `#[param(default=...)]` or `Default::default()` value in a sketch's derived `ParameterMetadata` listing.

Fixes #27 